### PR TITLE
p4c emit psa-style path based metadata

### DIFF
--- a/backends/bmv2/common/expression.cpp
+++ b/backends/bmv2/common/expression.cpp
@@ -239,6 +239,8 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
     cstring fieldName = expression->member.name;
     auto type = typeMap->getType(expression, true);
 
+    std::cout << "->>>>>> WORKING ON FIELD " << fieldName << "\n";
+
     if (parentType->is<IR::Type_StructLike>()) {
         auto st = parentType->to<IR::Type_StructLike>();
         auto field = st->getField(expression->member);
@@ -262,6 +264,7 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
     if (param != nullptr) {
         // convert architecture-dependent parameter
         if (auto result = convertParam(param, fieldName)) {
+
             mapExpression(expression, result);
             return;
         }
@@ -290,6 +293,10 @@ void ExpressionConverter::postorder(const IR::Member* expression)  {
                     type->is<IR::Type_Boolean>())) {
             auto field = parentType->to<IR::Type_StructLike>()->getField(
                 expression->member);
+
+            // XXX: DEBUG
+            std::cout << "->>>>>>>> looking up field " << field;
+
             LOG3("looking up field " << field);
             CHECK_NULL(field);
             auto name = ::get(structure->scalarMetadataFields, field);

--- a/backends/bmv2/common/helpers.cpp
+++ b/backends/bmv2/common/helpers.cpp
@@ -24,8 +24,13 @@ const cstring TableImplementation::actionSelectorName = "action_selector";
 const cstring MatchImplementation::selectorMatchTypeName = "selector";
 const cstring MatchImplementation::rangeMatchTypeName = "range";
 const unsigned TableAttributes::defaultTableSize = 1024;
+
+// XXX: this seems to be deprecated
 const cstring V1ModelProperties::jsonMetadataParameterName = "standard_metadata";
+
 const cstring V1ModelProperties::validField = "$valid$";
+
+
 
 Util::IJson* nodeName(const CFG::Node* node) {
     if (node->name.isNullOrEmpty())
@@ -83,5 +88,3 @@ unsigned nextId(cstring group) {
 }
 
 }  // namespace BMV2
-
-

--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+#include "backends/bmv2/common/annotations.h"
 #include "frontends/common/model.h"
 #include "psaSwitch.h"
 
@@ -92,11 +93,19 @@ void PsaProgramStructure::createStructLike(ConversionContext* ctxt, const IR::Ty
 }
 
 void PsaProgramStructure::createTypes(ConversionContext* ctxt) {
-    for (auto kv : header_types)
+    std::cout << "trying headers now\n";
+    for (auto kv : header_types) {
+        std::cout << "----- HEADER TYPE " << kv.second->name << " -----\n";
         createStructLike(ctxt, kv.second);
-    for (auto kv : metadata_types)
+    }
+    std::cout << "trying metadata now\n";
+    for (auto kv : metadata_types) {
+        std::cout << "----- META TYPE " << kv.second->name << " -----\n";
         createStructLike(ctxt, kv.second);
+    }
+    std::cout << "trying unions now\n";
     for (auto kv : header_union_types) {
+        std::cout << "----- UNION TYPE " << kv.second->name << " -----\n";
         auto st = kv.second;
         auto fields = new Util::JsonArray();
         for (auto f : st->fields) {
@@ -431,6 +440,7 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
     PassManager simplify = {
         /* TODO */
         // new RenameUserMetadata(refMap, userMetaType, userMetaName),
+        new ParseAnnotations(),
         new P4::ClearTypeMap(typeMap),  // because the user metadata type has changed
         // new P4::SynthesizeActions(refMap, typeMap, new SkipControls(&non_pipeline_controls)),
         new P4::MoveActionsToTables(refMap, typeMap),

--- a/p4include/psa.p4
+++ b/p4include/psa.p4
@@ -279,16 +279,19 @@ enum PSA_PacketPath_t {
     RECIRCULATE /// Packet arrival is the result of a recirculate operation
 }
 
+@metadata @name("psa_metadata")
 struct psa_ingress_parser_input_metadata_t {
   PortId_t                 ingress_port;
   PSA_PacketPath_t         packet_path;
 }
 
+@metadata @name("psa_metadata")
 struct psa_egress_parser_input_metadata_t {
   PortId_t                 egress_port;
   PSA_PacketPath_t         packet_path;
 }
 
+@metadata @name("psa_metadata")
 struct psa_ingress_input_metadata_t {
   // All of these values are initialized by the architecture before
   // the Ingress control block begins executing.
@@ -297,7 +300,9 @@ struct psa_ingress_input_metadata_t {
   Timestamp_t              ingress_timestamp;
   ParserError_t            parser_error;
 }
+
 // BEGIN:Metadata_ingress_output
+@metadata @name("psa_metadata")
 struct psa_ingress_output_metadata_t {
   // The comment after each field specifies its initial value when the
   // Ingress control block begins executing.
@@ -309,7 +314,9 @@ struct psa_ingress_output_metadata_t {
   MulticastGroup_t         multicast_group;  // 0
   PortId_t                 egress_port;      // initial value is undefined
 }
+
 // END:Metadata_ingress_output
+@metadata @name("psa_metadata")
 struct psa_egress_input_metadata_t {
   ClassOfService_t         class_of_service;
   PortId_t                 egress_port;
@@ -322,10 +329,13 @@ struct psa_egress_input_metadata_t {
 /// This struct is an 'in' parameter to the egress deparser.  It
 /// includes enough data for the egress deparser to distinguish
 /// whether the packet should be recirculated or not.
+@metadata @name("psa_metadata")
 struct psa_egress_deparser_input_metadata_t {
   PortId_t                 egress_port;
 }
+
 // BEGIN:Metadata_egress_output
+@metadata @name("psa_metadata")
 struct psa_egress_output_metadata_t {
   // The comment after each field specifies its initial value when the
   // Egress control block begins executing.


### PR DESCRIPTION
work in progress as of 3.3.19
**this is currently halted to work on PsaProgramStructure actually picking up the path-based metadata**

changelog:
- annotate psa.p4 with metadata tags (still TBD if needed - this was copied from v1model.p4)
- update std metadata param checking to check each of the related psa path controls

todo:
- remove debug prints