### PR TITLE
Add psa specific metadata to bmv2 psa_switch backend

### DIFF
--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -121,7 +121,7 @@ void PsaProgramStructure::createHeaders(ConversionContext* ctxt) {
     }
     for (auto kv : metadata) {
         auto type = kv.second->type->to<IR::Type_StructLike>();
-        ctxt->json->add_header(type->controlPlaneName(), kv.second->name);
+        ctxt->json->add_metadata(type->controlPlaneName(), kv.second->name);
     }
     /* TODO */
     // for (auto kv : header_stacks) {
@@ -372,6 +372,21 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
     }
 }
 
+bool InspectPsaProgram::isStandardMetadata(const IR::Type_StructLike* st) {
+    cstring stName = st->toString();
+    if (!strcmp(stName, "struct psa_ingress_parser_input_metadata_t") ||
+	!strcmp(stName, "struct psa_egress_parser_input_metadata_t") ||
+	!strcmp(stName, "struct psa_ingress_input_metadata_t") ||
+	!strcmp(stName, "struct psa_ingress_output_metadata_t") ||
+	!strcmp(stName, "struct psa_egress_input_metadata_t") ||
+	!strcmp(stName, "struct psa_egress_deparser_input_metadata_t") ||
+	!strcmp(stName, "struct psa_egress_output_metadata_t")) {
+        return true;
+    } else {
+        return false;
+    }
+}
+  
 // This visitor only visits the parameter in the statement from architecture.
 bool InspectPsaProgram::preorder(const IR::Parameter* param) {
     auto ft = typeMap->getType(param->getNode(), true);
@@ -383,6 +398,12 @@ bool InspectPsaProgram::preorder(const IR::Parameter* param) {
     // parameter must be a type that we have not seen before
     if (pinfo->hasVisited(st))
         return false;
+    // check if it is psa specific standard metadata
+    if (isStandardMetadata(st)) {
+      addHeaderType(st);
+      // remove struct and _t from type name
+      addHeaderInstance(st, (st->toString()).substr(7,st->toString().size()-9));
+    }    
     auto isHeader = isHeaders(st);
     addTypesAndInstances(st, isHeader);
     return false;

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -188,6 +188,7 @@ class InspectPsaProgram : public Inspector {
     void postorder(const IR::Declaration_Instance* di) override;
 
     bool isHeaders(const IR::Type_StructLike* st);
+    bool isStandardMetadata(const IR::Type_StructLike* st);
     void addTypesAndInstances(const IR::Type_StructLike* type, bool meta);
     void addHeaderType(const IR::Type_StructLike *st);
     void addHeaderInstance(const IR::Type_StructLike *st, cstring name);


### PR DESCRIPTION
changelog:
Modify psaSwitch.cpp to emit metadata in accordance to https://github.com/jafingerhut/p4-guide/blob/master/psa-examples/README-psa-implementation.md. 

test:
make -j4 check

todo:
change commit to not be authored by vagrant lol
