### PR TITLE
Add psa specific metadata to bmv2 psa_switch backend

### DIFF
--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -372,19 +372,14 @@ void InspectPsaProgram::addTypesAndInstances(const IR::Type_StructLike* type, bo
     }
 }
 
-bool InspectPsaProgram::isStandardMetadata(const IR::Type_StructLike* st) {
-    cstring stName = st->toString();
-    if (!strcmp(stName, "struct psa_ingress_parser_input_metadata_t") ||
-        !strcmp(stName, "struct psa_egress_parser_input_metadata_t") ||
-        !strcmp(stName, "struct psa_ingress_input_metadata_t") ||
-        !strcmp(stName, "struct psa_ingress_output_metadata_t") ||
-        !strcmp(stName, "struct psa_egress_input_metadata_t") ||
-        !strcmp(stName, "struct psa_egress_deparser_input_metadata_t") ||
-        !strcmp(stName, "struct psa_egress_output_metadata_t")) {
-      return true;
-    } else {
-      return false;
-  }
+bool InspectPsaProgram::isStandardMetadata(cstring ptName) {
+    return (!strcmp(ptName, "psa_ingress_parser_input_metadata_t") ||
+        !strcmp(ptName, "psa_egress_parser_input_metadata_t") ||
+        !strcmp(ptName, "psa_ingress_input_metadata_t") ||
+        !strcmp(ptName, "psa_ingress_output_metadata_t") ||
+        !strcmp(ptName, "psa_egress_input_metadata_t") ||
+        !strcmp(ptName, "psa_egress_deparser_input_metadata_t") ||
+        !strcmp(ptName, "psa_egress_output_metadata_t"));
 }
 
 // This visitor only visits the parameter in the statement from architecture.
@@ -396,10 +391,12 @@ bool InspectPsaProgram::preorder(const IR::Parameter* param) {
         return false;
     auto st = ft->to<IR::Type_StructLike>();
     // check if it is psa specific standard metadata
-    if (isStandardMetadata(st)) {
+    cstring ptName = param->type->toString();
+    if (isStandardMetadata(ptName)) {
       addHeaderType(st);
-      // remove struct and _t from type name
-      addHeaderInstance(st, (st->toString()).substr(7, st->toString().size()-9));
+      // remove _t from type name
+      cstring headerName = ptName.exceptLast(2);
+      addHeaderInstance(st, headerName);
     }
     // parameter must be a type that we have not seen before
     if (pinfo->hasVisited(st))

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -188,6 +188,7 @@ class InspectPsaProgram : public Inspector {
     void postorder(const IR::Declaration_Instance* di) override;
 
     bool isHeaders(const IR::Type_StructLike* st);
+    bool isStandardMetadata(const IR::Type_StructLike* st);
     void addTypesAndInstances(const IR::Type_StructLike* type, bool meta);
     void addHeaderType(const IR::Type_StructLike *st);
     void addHeaderInstance(const IR::Type_StructLike *st, cstring name);

--- a/backends/bmv2/psa_switch/psaSwitch.h
+++ b/backends/bmv2/psa_switch/psaSwitch.h
@@ -188,7 +188,7 @@ class InspectPsaProgram : public Inspector {
     void postorder(const IR::Declaration_Instance* di) override;
 
     bool isHeaders(const IR::Type_StructLike* st);
-    bool isStandardMetadata(const IR::Type_StructLike* st);
+    bool isStandardMetadata(cstring ptName);
     void addTypesAndInstances(const IR::Type_StructLike* type, bool meta);
     void addHeaderType(const IR::Type_StructLike *st);
     void addHeaderInstance(const IR::Type_StructLike *st, cstring name);


### PR DESCRIPTION
changelog:
Modify psaSwitch.cpp to emit metadata in accordance to https://github.com/jafingerhut/p4-guide/blob/master/psa-examples/README-psa-implementation.md.

test:
make -j4 check

todo: