### PR TITLE
emit psa_packet_paths

### DIFF
--- a/backends/bmv2/psa_switch/psaSwitch.cpp
+++ b/backends/bmv2/psa_switch/psaSwitch.cpp
@@ -482,8 +482,13 @@ void PsaSwitchBackend::convert(const IR::ToplevelBlock* tlb) {
         new InspectPsaProgram(refMap, typeMap, &structure),
         new ConvertPsaToJson(refMap, typeMap, toplevel, json, &structure)
     };
+    for (const auto &pEnum : *enumMap) {
+      auto name = pEnum.first->getName();
+      for (const auto &pEntry : *pEnum.second) {
+        json->add_enum(name, pEntry.first, pEntry.second);
+      }
+    }
     program->apply(toJson);
-
     json->add_program_info(options.file);
     json->add_meta_info();
 }


### PR DESCRIPTION
I think we said we aren't merging to ours, please leave a comment if you think its ok. Its just a copy and paste from simple switch, it will let us use the packet path values in bmv2. This is also blocking our bmv2 PR.